### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ pip install fastapi_amis_admin
 
 ### Note
 
-- `sqlmodel` currently does not support `sqlalchemy 2.0+`. If you use `sqlalchemy 2.0+` to create a model, you cannot
-  use `sqlmodel` at the same time.
 - After version `fastapi-amis-admin>=0.6.0`, `sqlmodel` is no longer a required dependency library. If you use `sqlmodel`
   to create a model, you can install it with the following command.
 


### PR DESCRIPTION
sqlmodel support SQLAlchemy v2 now. https://github.com/tiangolo/sqlmodel/releases/tag/0.0.12