### PR TITLE
[Bug] Fix: pydantic.errors.PydanticUserError: Field 'id' requires a type annotation

### DIFF
--- a/fastapi_amis_admin/crud/parser.py
+++ b/fastapi_amis_admin/crud/parser.py
@@ -348,15 +348,17 @@ def insfield_to_modelfield(insfield: InstrumentedAttribute) -> Optional[ModelFie
         elif expression.default.is_callable:
             field_info_kwargs["default_factory"] = expression.default.arg
             required = False
-    if isinstance(expression.type, String):
+    if isinstance(expression.type, String) and expression.type.length:
         field_info_kwargs["max_length"] = expression.type.length
-    if "default_factory" not in field_info_kwargs:
+    if "default_factory" not in field_info_kwargs and default:
         field_info_kwargs["default"] = default
     type_ = expression.type.python_type
     if PYDANTIC_V2:
         field_info_kwargs["annotation"] = type_
+    if expression.comment:
+        field_info_kwargs["title"] = expression.comment
     return create_response_field(
-        name=insfield.key, type_=type_, required=required, field_info=Field(title=expression.comment, **field_info_kwargs)
+        name=insfield.key, type_=type_, required=required, field_info=FieldInfo(**field_info_kwargs)
     )
 
 


### PR DESCRIPTION
I fix a problem when create from sqlalchemy 2.0 model, without pydantic model.

```
raise PydanticUserError(
pydantic.errors.PydanticUserError: Field 'id' requires a type annotation
```
